### PR TITLE
Readahead shadow load

### DIFF
--- a/testing/mock_redis.py
+++ b/testing/mock_redis.py
@@ -7,6 +7,7 @@ class MockRedis():
         self.set_parms = []
         self.success_flag = True
         self.derived_pipeline = None
+        self.sadd_parms = []
 
     def get(self, key):
         self.get_parms.append([key])
@@ -21,6 +22,10 @@ class MockRedis():
     def pipeline(self):
         self.derived_pipeline = MockRedisPipeline()
         return self.derived_pipeline
+
+    def sadd(self, key, element):
+        self.sadd_parms.append([key, element])
+        return 1
 
 
 class MockRedisPipeline():

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -1,0 +1,38 @@
+
+from testing.mock_redis import MockRedis
+
+from tscached.shadow import process_for_readahead
+from tscached.shadow import should_add_to_readahead
+
+
+EX_CONFIG = {'shadow': {'http_header_name': 'Tscached-Shadow-Load', 'referrer_blacklist': ['edit']}}
+HEADER_YES = {'Tscached-Shadow-Load': 'whatever'}
+HEADER_NO = {}
+
+
+def test_should_add_to_readahead_header_set():
+    assert should_add_to_readahead(EX_CONFIG, 'http://whatever', HEADER_YES) is True
+
+
+def test_should_add_to_readahead_edit_url_with_header():
+    assert should_add_to_readahead(EX_CONFIG, 'http://grafana/blah&edit', HEADER_YES) is True
+
+
+def test_should_add_to_readahead_edit_url_no_header():
+    assert should_add_to_readahead(EX_CONFIG, 'http://grafana/blah&edit', HEADER_NO) is False
+
+
+def test_should_add_to_readahead_sane_url_no_header():
+    assert should_add_to_readahead(EX_CONFIG, 'http://grafana/blah', HEADER_NO) is True
+
+
+def test_process_for_readahead_yes():
+    redis_cli = MockRedis()
+    process_for_readahead(EX_CONFIG, redis_cli, 'tscached:kquery:WAT', 'http://wooo?edit', HEADER_YES)
+    assert redis_cli.sadd_parms == [['tscached:shadow', 'tscached:kquery:WAT']]
+
+
+def test_process_for_readahead_no():
+    redis_cli = MockRedis()
+    process_for_readahead(EX_CONFIG, redis_cli, 'tscached:kquery:WAT', 'http://wooo?edit', HEADER_NO)
+    assert redis_cli.sadd_parms == []

--- a/tscached.yaml
+++ b/tscached.yaml
@@ -24,3 +24,10 @@ tscached:
         default_expiry: 10800  # 3 hours, in seconds
         expected_resolution: 10000  # in milliseconds
         acceptable_skew: 6  # for merging purposes
+
+    shadow:  # in seconds
+        http_header_name: 'Tscached-Shadow-Load'
+        update_interval: 60  # how often to run the update script (secs)
+        leader_expiration: 120  # TTL (sec) on the leader flag - which server runs updates
+        referrer_blacklist:  # if the referrer contains any of these, do not do readahead.
+        - 'edit'

--- a/tscached.yaml
+++ b/tscached.yaml
@@ -30,4 +30,5 @@ tscached:
         update_interval: 60  # how often to run the update script (secs)
         leader_expiration: 120  # TTL (sec) on the leader flag - which server runs updates
         referrer_blacklist:  # if the referrer contains any of these, do not do readahead.
-        - 'edit'
+        - 'edit'      # grafana edit views
+        - 'tscached'  # commonly part of the URL for the debug UI

--- a/tscached/handler_general.py
+++ b/tscached/handler_general.py
@@ -9,6 +9,7 @@ import redis
 from tscached import app
 from tscached import cache_calls
 from tscached.kquery import KQuery
+from tscached.shadow import process_for_readahead
 from tscached.utils import FETCH_AFTER
 from tscached.utils import FETCH_ALL
 from tscached.utils import FETCH_BEFORE
@@ -51,6 +52,9 @@ def handle_query():
     # HTTP request may contain one or more kqueries
     for kquery in KQuery.from_request(payload, redis_client):
         kq_result = kquery.get_cached()
+
+        # readahead shadow load support
+        populate_for_readahead(config, redis_client, kquery.get_key(), request.referrer, request.headers)
 
         if kq_result:
             try:

--- a/tscached/handler_general.py
+++ b/tscached/handler_general.py
@@ -54,7 +54,7 @@ def handle_query():
         kq_result = kquery.get_cached()
 
         # readahead shadow load support
-        populate_for_readahead(config, redis_client, kquery.get_key(), request.referrer, request.headers)
+        process_for_readahead(config, redis_client, kquery.get_key(), request.referrer, request.headers)
 
         if kq_result:
             try:

--- a/tscached/shadow.py
+++ b/tscached/shadow.py
@@ -17,7 +17,7 @@ def should_add_to_readahead(config, referrer, headers):
     return True
 
 
-def populate_for_readahead(config, redis_client, kquery_key, referrer, headers):
+def process_for_readahead(config, redis_client, kquery_key, referrer, headers):
     """ Couple this KQuery to readahead behavior.
         config: dict representing the top-level tscached config
         redis_client: redis.StrictRedis

--- a/tscached/shadow.py
+++ b/tscached/shadow.py
@@ -1,0 +1,33 @@
+import logging
+
+
+def should_add_to_readahead(config, referrer, headers):
+    """ Should we add this KQuery for readahead behavior?
+        config: dict representing the top-level tscached config
+        referrer: str, from the http request
+        headers: dict, all headers from the http request
+        returns: boolean
+    """
+    if headers.get(config['shadow']['http_header_name'], None):
+        return True
+
+    for substr in config['shadow']['referrer_blacklist']:
+        if substr in referrer:
+            return False
+    return True
+
+
+def populate_for_readahead(config, redis_client, kquery_key, referrer, headers):
+    """ Couple this KQuery to readahead behavior.
+        config: dict representing the top-level tscached config
+        redis_client: redis.StrictRedis
+        kquery_key: str, usually tscached:kquery:HASH
+        referrer: str, from the http request
+        headers: dict, all headers from the http request
+        returns: void
+    """
+    if should_add_to_readahead(config, referrer, headers):
+        resp = redis_client.sadd('tscached:shadow', kquery_key)
+        logging.info('Shadow: Added %d key: %s' % (resp, kquery_key))
+    else:
+        logging.debug('Shadow: NOT adding key: %s' % kquery_key)


### PR DESCRIPTION
This is the web server bit of it - will need to write the cron job that then reads from this data.
- For every KQuery parsed from an HTTP request, decide if it needs to be added to a Redis set for caching.
- If a certain HTTP header is set on the request, it will always be added.
- If a certain string is inside the refer(r)er, it will never be added.
- Full test coverage.
