### PR TITLE
Handle backend failures

### DIFF
--- a/tscached.yaml
+++ b/tscached.yaml
@@ -24,6 +24,7 @@ tscached:
         default_expiry: 10800  # 3 hours, in seconds
         expected_resolution: 10000  # in milliseconds
         acceptable_skew: 6  # for merging purposes
+        staleness_threshold: 10  # data up to this far in the past is "new"
 
     shadow:  # in seconds
         http_header_name: 'Tscached-Shadow-Load'

--- a/tscached/cache_calls.py
+++ b/tscached/cache_calls.py
@@ -4,9 +4,49 @@ import logging
 import simplejson as json
 
 from tscached.mts import MTS
+from tscached.utils import BackendQueryFailure
 from tscached.utils import FETCH_AFTER
+from tscached.utils import FETCH_ALL
 from tscached.utils import FETCH_BEFORE
+from tscached.utils import get_range_needed
 from tscached.utils import get_needed_absolute_time_range
+
+
+def process_cache_hit(config, redis_client, kquery, kairos_time_range):
+    """ KQuery found in cache. Decide whether to return solely cached data or to update cached data.
+        If cached data should be updated, figure out how to do it.
+        :param config: 'tscached' level from config file.
+        :param redis_client: redis.StrictRedis
+        :param kquery: kquery.KQuery object
+        :param kairos_time_range: dict, time range straight from the HTTP request payload
+        :return: dict, kquery response to be added to HTTP response
+        :raise: utils.BackendQueryFailure, if a Kairos lookup failed.
+    """
+    # this relies on KQuery.get_cached() having a side effect. it must be called before this function.
+    kq_result = kquery.cached_data
+    try:
+        start_cache = datetime.datetime.fromtimestamp(float(kq_result['earliest_data']))
+        end_cache = datetime.datetime.fromtimestamp(float(kq_result['last_add_data']))
+    except:  # some sort of cache malformation or error, doesn't matter what.
+        start_cache = None
+        end_cache = None
+
+    start_request, end_request = get_needed_absolute_time_range(kairos_time_range)
+    staleness_threshold = config['data']['staleness_threshold']
+
+    range_needed = get_range_needed(start_request, end_request, start_cache,
+                                    end_cache, staleness_threshold)
+    if not range_needed:  # hot cache
+        return hot(redis_client, kquery, kairos_time_range)
+    else:
+        merge_method = range_needed[2]
+        if merge_method == FETCH_ALL:  # warm, but data doesn't support merging.
+            logging.info('Odd COLD scenario: data exists.')
+            return cold(config, redis_client, kquery, kairos_time_range)
+        elif merge_method in [FETCH_BEFORE, FETCH_AFTER]:  # warm, merging supported.
+            return warm(config, redis_client, kquery, kairos_time_range, range_needed)
+        else:
+            raise BackendQueryFailure("Received unsupported range_needed value: %s" % range_needed[2])
 
 
 def cold(config, redis_client, kquery, kairos_time_range):
@@ -16,9 +56,9 @@ def cold(config, redis_client, kquery, kairos_time_range):
     start_time, end_time = get_needed_absolute_time_range(kairos_time_range)
 
     response_kquery = {'results': [], 'sample_size': 0}
-    kairos_result = kquery.proxy_to_kairos(config['kairosdb']['host'],
-                                           config['kairosdb']['port'],
+    kairos_result = kquery.proxy_to_kairos(config['kairosdb']['host'], config['kairosdb']['port'],
                                            kairos_time_range)
+
     pipeline = redis_client.pipeline()
     # Loop over every MTS
     for mts in MTS.from_result(kairos_result['queries'][0], redis_client):
@@ -57,12 +97,11 @@ def warm(config, redis_client, kquery, kairos_time_range, range_needed):
     expected_resolution = config['data'].get('expected_resolution', 10000)
 
     time_dict = {
-                    'start_absolute': int(range_needed[0].strftime('%s')) * 1000,
-                    'end_absolute': int(range_needed[1].strftime('%s')) * 1000 - expected_resolution,
+                    'start_absolute': int(range_needed[0].strftime('%s')) * 1000 - expected_resolution,
+                    'end_absolute': int(range_needed[1].strftime('%s')) * 1000,
                 }
 
-    new_kairos_result = kquery.proxy_to_kairos(config['kairosdb']['host'],
-                                               config['kairosdb']['port'],
+    new_kairos_result = kquery.proxy_to_kairos(config['kairosdb']['host'], config['kairosdb']['port'],
                                                time_dict)
 
     response_kquery = {'results': [], 'sample_size': 0}
@@ -80,7 +119,6 @@ def warm(config, redis_client, kquery, kairos_time_range, range_needed):
     # loop over newly returned MTS. if they already existed, merge/write. if not, just write.
     pipeline = redis_client.pipeline()
     for mts in MTS.from_result(new_kairos_result['queries'][0], redis_client):
-        logging.debug("Size of cached_mts: %d" % len(cached_mts.keys()))
 
         old_mts = cached_mts.get(mts.get_key())
         if not old_mts:  # This MTS just started reporting and isn't yet in the cache (cold behavior).

--- a/tscached/handler_meta.py
+++ b/tscached/handler_meta.py
@@ -45,6 +45,7 @@ def metadata_caching(config, name, endpoint, post_data=None):
             else:
                 kairos_result = requests.get(url)
         except requests.exceptions.RequestException as e:
+            logging.error('BackendQueryFailure: %s' % e.message)
             return json.dumps({'error': 'Could not connect to KairosDB: %s' % e.message}), 500
 
         if kairos_result.status_code != 200:

--- a/tscached/kquery.py
+++ b/tscached/kquery.py
@@ -29,10 +29,17 @@ class KQuery(DataCache):
         return self.query
 
     def proxy_to_kairos(self, host, port, time_range):
-        """ time_range can be generated via utils.populate_time_range """
+        """ Send this KQuery to Kairos with a custom time range and get the response.
+            host: str, kairosdb host.
+            port: int, kairosdb port.
+            time_range: dict, usually generated via utils.populate_time_range
+            returns: dict, the response from kairos
+            raises: utils.BackendQueryFailure, if the query fails.
+        """
         proxy_query = copy.deepcopy(time_range)
         proxy_query['metrics'] = [self.query]
         proxy_query['cache_time'] = 0
+
         kairos_result = query_kairos(host, port, proxy_query)
 
         if len(kairos_result['queries']) != 1:

--- a/tscached/mts.py
+++ b/tscached/mts.py
@@ -181,10 +181,10 @@ class MTS(DataCache):
             start_trim, end_trim = get_needed_absolute_time_range(time_range)
 
             if self.conforms_to_efficient_constraints():
-                logging.debug('Efficient trimming: %s, %s' % (start_trim, end_trim))
+                # logging.debug('Efficient trimming: %s, %s' % (start_trim, end_trim))
                 new_values = self.efficient_trim(start_trim, end_trim)
             else:
-                logging.debug('Robust trimming: %s, %s' % (start_trim, end_trim))
+                # logging.debug('Robust trimming: %s, %s' % (start_trim, end_trim))
                 new_values = list(self.robust_trim(start_trim, end_trim))
 
             # shallow copy just at the first level of the dict

--- a/tscached/utils.py
+++ b/tscached/utils.py
@@ -45,7 +45,11 @@ def query_kairos(kairos_host, kairos_port, query):
     try:
         url = 'http://%s:%s/api/v1/datapoints/query' % (kairos_host, kairos_port)
         r = requests.post(url, data=json.dumps(query))
-        return json.loads(r.text)
+        value = json.loads(r.text)
+        if r.status_code / 100 != 2:
+            message = ', '.join(value.get('errors', ['No message given']))
+            raise BackendQueryFailure('KairosDB responded %d: %s' % (r.status_code, message))
+        return value
     except requests.exceptions.RequestException as e:
         raise BackendQueryFailure('Could not connect to KairosDB: %s' % e.message)
 


### PR DESCRIPTION
KairosDB failures now propagate through exception handling. The web worker will return a 500 gracefully rather than blowing up.

There's a _large_ refactor of handler_general to make exception handling cleaner. This 

I added a test to verify the correct exception will be raised. Smoke test shows equivalent behavior to before.
