### PR TITLE
Redis resilience

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ envdir = venv-{[tox]projectname}
 commands =
 
 [flake8]
-exclude = .git,__pycache__,.tox,docs,build,virtualenv_run,env,venv,uwsgi.py,__init__.py
+exclude = .git,__pycache__,.tox,docs,build,virtualenv_run,env,venv,uwsgi.py,debug-run.py,__init__.py
 ; ignore = E731
 max-line-length = 120
 

--- a/tscached/cache_calls.py
+++ b/tscached/cache_calls.py
@@ -144,10 +144,13 @@ def warm(config, redis_client, kquery, kairos_time_range, range_needed):
 
             pipeline.set(old_mts.get_key(), json.dumps(old_mts.result), ex=old_mts.expiry)
             response_kquery = old_mts.build_response(kairos_time_range, response_kquery)
+    try:
+        result = pipeline.execute()
+        success_count = len(filter(lambda x: x is True, result))
+        logging.info("MTS write pipeline: %d of %d successful" % (success_count, len(result)))
 
-    result = pipeline.execute()
-    success_count = len(filter(lambda x: x is True, result))
-    logging.info("MTS write pipeline: %d of %d successful" % (success_count, len(result)))
-
-    kquery.upsert(new_start_time, new_end_time)
+        kquery.upsert(new_start_time, new_end_time)
+    except redis.exceptions.RedisError as e:
+        # Sneaky edge case where Redis fails after reading but before writing. Still return data!
+        logging.error('RedisError: ' + e.message)
     return response_kquery

--- a/tscached/cache_calls.py
+++ b/tscached/cache_calls.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+import redis
 import simplejson as json
 
 from tscached.mts import MTS
@@ -66,11 +67,16 @@ def cold(config, redis_client, kquery, kairos_time_range):
         pipeline.set(mts.get_key(), json.dumps(mts.result), ex=mts.expiry)
         response_kquery = mts.build_response(kairos_time_range, response_kquery, trim=False)
 
-    result = pipeline.execute()
-    success_count = len(filter(lambda x: x is True, result))
-    logging.info("MTS write pipeline: %d of %d successful" % (success_count, len(result)))
+    try:
+        result = pipeline.execute()
+        success_count = len(filter(lambda x: x is True, result))
+        logging.info("MTS write pipeline: %d of %d successful" % (success_count, len(result)))
 
-    kquery.upsert(start_time, end_time)  # TODO
+        kquery.upsert(start_time, end_time)  # TODO
+    except redis.exceptions.RedisError as e:
+        # We want to eat this redis exception, because in a catastrophe this becones a straight proxy.
+        logging.error('RedisError: ' + e.message)
+
     return response_kquery
 
 

--- a/tscached/handler_meta.py
+++ b/tscached/handler_meta.py
@@ -6,7 +6,6 @@ import requests
 import simplejson as json
 
 from tscached import app
-from tscached.utils import CacheQueryFailure
 from tscached.utils import create_key
 
 
@@ -59,7 +58,8 @@ def metadata_caching(config, name, endpoint, post_data=None):
             value = json.loads(kairos_result.text)
             value_message = ', '.join(value.get('errors', ['No message given']))
             message = 'Meta Endpoint: %s: KairosDB responded %d: %s' % (redis_key,
-                      kairos_result.status_code, message)
+                                                                        kairos_result.status_code,
+                                                                        value_message)
             return json.dumps({'error': message}), 500
         else:
             # kairos response seems to be okay

--- a/tscached/shadow.py
+++ b/tscached/shadow.py
@@ -3,10 +3,10 @@ import logging
 
 def should_add_to_readahead(config, referrer, headers):
     """ Should we add this KQuery for readahead behavior?
-        config: dict representing the top-level tscached config
-        referrer: str, from the http request
-        headers: dict, all headers from the http request
-        returns: boolean
+        :param config: dict representing the top-level tscached config
+        :param referrer: str, from the http request
+        :param headers: dict, all headers from the http request
+        :return: boolean
     """
     if headers.get(config['shadow']['http_header_name'], None):
         return True
@@ -18,13 +18,14 @@ def should_add_to_readahead(config, referrer, headers):
 
 
 def process_for_readahead(config, redis_client, kquery_key, referrer, headers):
-    """ Couple this KQuery to readahead behavior.
-        config: dict representing the top-level tscached config
-        redis_client: redis.StrictRedis
-        kquery_key: str, usually tscached:kquery:HASH
-        referrer: str, from the http request
-        headers: dict, all headers from the http request
-        returns: void
+    """ Couple this KQuery to readahead behavior. If Redis fails, eat the exception.
+        :param config: dict representing the top-level tscached config
+        :param redis_client: redis.StrictRedis
+        :param kquery_key: str, usually tscached:kquery:HASH
+        :param referrer: str, from the http request
+        :param headers: dict, all headers from the http request
+        :return: void:
+        :raise: redis.exceptions.RedisError
     """
     if should_add_to_readahead(config, referrer, headers):
         resp = redis_client.sadd('tscached:shadow', kquery_key)

--- a/tscached/utils.py
+++ b/tscached/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import hashlib
 
+import redis
 import requests
 import simplejson as json
 
@@ -25,6 +26,11 @@ FETCH_ALL = 'overwrite'
 
 class BackendQueryFailure(requests.exceptions.RequestException):
     """ Raised if the backing TS database (KairosDB) fails. """
+    pass
+
+
+class CacheQueryFailure(redis.exceptions.RedisError):
+    """ Raised if the backing cache (Redis) fails. """
     pass
 
 

--- a/tscached/utils.py
+++ b/tscached/utils.py
@@ -1,7 +1,6 @@
 import datetime
 import hashlib
 
-import redis
 import requests
 import simplejson as json
 
@@ -26,11 +25,6 @@ FETCH_ALL = 'overwrite'
 
 class BackendQueryFailure(requests.exceptions.RequestException):
     """ Raised if the backing TS database (KairosDB) fails. """
-    pass
-
-
-class CacheQueryFailure(redis.exceptions.RedisError):
-    """ Raised if the backing cache (Redis) fails. """
     pass
 
 


### PR DESCRIPTION
Much like the Kairos resiliency work in #2,  this allows tscached to behave like a straight proxy to kairosdb if redis ever fails. We catch the generic `redis.exceptions.RedisError` throughout the critical path (cold/miss) and swallow/log it each time.

Unfortunately, the redis-py library doesn't offer persistent health checks; in fact, on instantiation of the client no network traffic occurs. ~~Because of this, handling failures in a warm/update lookup constitutes diminishing returns. We accept that, if redis fails _midway through processing an update request_, we will throw a nasty exception.~~ (All edge cases should be handled!)

There are a handful of other cleanups that snuck into this pull as well.
