### PR TITLE
Readahead batch

### DIFF
--- a/readahead.py
+++ b/readahead.py
@@ -1,23 +1,12 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
 import os
-import logging
-import sys
 
 import argparse
 import redis
 import yaml
 
 from tscached.shadow import perform_readahead
-
-
-def setup_logging():
-    logger = logging.getLogger()
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(logging.DEBUG)
 
 
 if __name__ == '__main__':

--- a/readahead.py
+++ b/readahead.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+import os
+import logging
+import sys
+
+import argparse
+import redis
+import yaml
+
+from tscached.shadow import perform_readahead
+
+
+def setup_logging():
+    logger = logging.getLogger()
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Harness for querying/testing tscached/kairosdb')
+
+    parser.add_argument('-c', '--config', type=str, default=os.path.abspath('tscached.yaml'),
+                        help='Path to config file.')
+    args = parser.parse_args()
+
+    with open(args.config, 'r') as config_file:
+        config = yaml.load(config_file.read())['tscached']
+
+    redis_client = redis.StrictRedis(host=config['redis']['host'], port=config['redis']['port'])
+    perform_readahead(config, redis_client)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==0.10.1
 PyYAML==3.11
 argparse==1.4.0
 redis==2.10.5
+redlock==1.2.0
 requests==2.9.1
 simplejson==3.8.1
 uWSGI==2.0.12

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -29,7 +29,7 @@ def test_should_add_to_readahead_sane_url_no_header():
 def test_process_for_readahead_yes():
     redis_cli = MockRedis()
     process_for_readahead(EX_CONFIG, redis_cli, 'tscached:kquery:WAT', 'http://wooo?edit', HEADER_YES)
-    assert redis_cli.sadd_parms == [['tscached:shadow', 'tscached:kquery:WAT']]
+    assert redis_cli.sadd_parms == [['tscached:shadow_list', 'tscached:kquery:WAT']]
 
 
 def test_process_for_readahead_no():

--- a/tscached.yaml
+++ b/tscached.yaml
@@ -28,8 +28,8 @@ tscached:
 
     shadow:  # in seconds
         http_header_name: 'Tscached-Shadow-Load'
-        update_interval: 60  # how often to run the update script (secs)
-        leader_expiration: 120  # TTL (sec) on the leader flag - which server runs updates
+        update_interval: 300  # how often to run the update script (secs)
+        leader_expiration: 3600  # TTL (sec) on the leader flag - which server runs updates
         referrer_blacklist:  # if the referrer contains any of these, do not do readahead.
         - 'edit'      # grafana edit views
         - 'tscached'  # commonly part of the URL for the debug UI

--- a/tscached/__init__.py
+++ b/tscached/__init__.py
@@ -1,12 +1,17 @@
 from flask import Flask
 import yaml
 
+from tscached.utils import setup_logging
+
 
 app = Flask(__name__, static_url_path='', static_folder='kairos-web')
 
 # Inject our custom YAML-based config into the Flask app.
 with open('tscached.yaml', 'r') as config_file:
     app.config['tscached'] = yaml.load(config_file.read())['tscached']
+
+if not app.debug:
+    setup_logging()
 
 
 import tscached.handler_general

--- a/tscached/handler_general.py
+++ b/tscached/handler_general.py
@@ -13,15 +13,6 @@ from tscached.utils import BackendQueryFailure
 from tscached.utils import populate_time_range
 
 
-if not app.debug:
-    logger = logging.getLogger()
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(logging.DEBUG)
-
-
 @app.route('/', methods=['GET'])
 def handle_root():
     if os.path.exists('tscached/kairos-web/index.html'):

--- a/tscached/shadow.py
+++ b/tscached/shadow.py
@@ -1,4 +1,13 @@
 import logging
+import socket
+
+import redis
+import redlock
+
+
+SHADOW_LOCK_KEY = 'tscached:shadow_lock'
+SHADOW_SERVER_KEY = 'tscached:shadow_server'
+SHADOW_LIST = 'tscached:shadow_list'
 
 
 def should_add_to_readahead(config, referrer, headers):
@@ -28,7 +37,66 @@ def process_for_readahead(config, redis_client, kquery_key, referrer, headers):
         :raise: redis.exceptions.RedisError
     """
     if should_add_to_readahead(config, referrer, headers):
-        resp = redis_client.sadd('tscached:shadow', kquery_key)
+        resp = redis_client.sadd(SHADOW_LIST, kquery_key)
         logging.info('Shadow: Added %d key: %s' % (resp, kquery_key))
     else:
         logging.debug('Shadow: NOT adding key: %s' % kquery_key)
+
+
+def become_leader(config, redis_client):
+    """ tscached can be deployed on multiple servers. Only one of them should exert shadow load.
+        We use RedLock (http://redis.io/topics/distlock) to achieve this. If we cannot acquire the
+        shadow lock, fail fast. If our server (or this program) crashes, the leader key will expire and
+        another server will take over eventually.
+
+        RedLock is (debatably) imperfect, but that's okay with us: our worst case is that some work gets
+        done twice -  because we are using Redis as a cache and *not* as a datastore. We're using one of
+        the standard Python clientlibs: https://github.com/glasslion/redlock
+
+        This implementation assumes a single-master Redis cluster.
+
+        :param config: dict representing the top-level tscached config
+        :param redis_client: redis.StrictRedis
+        :return: redlock.RedLock or False
+    """
+    hostname = socket.gethostname()
+    leader_expiration = config['shadow'].get('leader_expiration', 120) * 1000  # ms expected
+    deets = [redis_client]  # no need to reinitialize a redis connection.
+
+    try:
+        lock = redlock.RedLock(SHADOW_LOCK_KEY, ttl=leader_expiration, connection_details=deets)
+        if lock.acquire():
+            # mostly for debugging purposes
+            redis_client.set(SHADOW_SERVER_KEY, hostname, px=leader_expiration)
+            logging.info('Lock acquired; now held by %s' % hostname)
+            return lock
+        else:
+            other_host = redis_client.get(SHADOW_SERVER_KEY)
+            logging.info('Could not acquire lock; lock is held by %s' % other_host)
+            return False
+    except redis.exceptions.RedisError as e:
+        logging.error('RedisError in acquire_leader: ' + e.message)
+        return False
+    except redlock.RedLockError:
+        logging.error('RedLockError in acquire_leader: ' + e.message)
+        return False
+
+
+def release_leader(lock, redis_client):
+    """ Release the lock acquired in become_leader. If we crash before doing this, no big deal:
+        the TTL will save us from doing anything dumb. Still, my mom taught me to clean up after myself.
+        :param lock: redlock.RedLock
+        :param lock: redis.StrictRedis
+        :return: bool, on success/failure
+    """
+    try:
+        lock.release()
+        redis_client.delete(SHADOW_SERVER_KEY)
+        logging.info('Lock released.')
+        return True
+    except redis.exceptions.RedisError as e:
+        logging.error('RedisError in release_leader: ' + e.message)
+        return False
+    except redlock.RedLockError:
+        logging.error('RedLockError in release_leader: ' + e.message)
+        return False

--- a/tscached/utils.py
+++ b/tscached/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import hashlib
+import logging
 
 import requests
 import simplejson as json
@@ -26,6 +27,15 @@ FETCH_ALL = 'overwrite'
 class BackendQueryFailure(requests.exceptions.RequestException):
     """ Raised if the backing TS database (KairosDB) fails. """
     pass
+
+
+def setup_logging():
+    logger = logging.getLogger()
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
 
 
 def get_timedelta(value):


### PR DESCRIPTION
First implementation of readahead support. The start point is in the top level directory with `readahead.py`.
- Use RedLock for coordination among different tscached hosts. Ideally we want only one readahead batch running at a time.
- Add a new classmethod, KQuery.from_cache, to use a redis key to lookup data without an external request. Previously we'd never needed this because all KQuery work was based on data sent from a user.
- A bit of cleanup for the logging infrastructure. Could be in a different PR, but it only became apparent when adding a non-HTTP entry point to the code base.
