### PR TITLE
Diagnostic response headers

### DIFF
--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -37,6 +37,14 @@ def test_should_add_to_readahead_sane_url_no_header():
     assert should_add_to_readahead(EX_CONFIG, 'http://grafana/blah', HEADER_NO) is True
 
 
+def test_should_add_to_readahead_no_referrer():
+    assert should_add_to_readahead(EX_CONFIG, None, HEADER_NO) is False
+
+
+def test_should_add_to_readahead_no_referrer_yes_header():
+    assert should_add_to_readahead(EX_CONFIG, None, HEADER_YES) is True
+
+
 def test_process_for_readahead_yes():
     redis_cli = MockRedis()
     process_for_readahead(EX_CONFIG, redis_cli, 'tscached:kquery:WAT', 'http://wooo?edit', HEADER_YES)

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -149,7 +149,7 @@ def test_perform_readahead_happy_path(m_process, m_from_cache, m_release_leader,
                           'redis_key': 'tscached:kquery:' + str(ndx)}
         kqueries.append(kq)
     m_from_cache.return_value = kqueries
-    m_process.return_value = {'sample_size': 666}
+    m_process.return_value = {'sample_size': 666}, 'warm_append'
 
     assert perform_readahead({}, redis_cli) is None
     assert m_become_leader.call_count == 1

--- a/tscached/shadow.py
+++ b/tscached/shadow.py
@@ -127,7 +127,8 @@ def perform_readahead(config, redis_client):
 
             # all that really matters is that end_ values are unset.
             kairos_time_range = {'start_relative': {'unit': 'minutes', 'value': str(mins_in_past)}}
-            kq_resp = cache_calls.process_cache_hit(config, redis_client, kq, kairos_time_range)
+            # throw away the diagnostic mode info for the moment.
+            kq_resp, _ = cache_calls.process_cache_hit(config, redis_client, kq, kairos_time_range)
             size = kq_resp.get('sample_size', -1)
             logging.debug('Processed KQuery %s; sample size now at %d' % (kq.redis_key, size))
     except BackendQueryFailure as e:

--- a/tscached/shadow.py
+++ b/tscached/shadow.py
@@ -17,12 +17,15 @@ SHADOW_LIST = 'tscached:shadow_list'
 def should_add_to_readahead(config, referrer, headers):
     """ Should we add this KQuery for readahead behavior?
         :param config: dict representing the top-level tscached config
-        :param referrer: str, from the http request
+        :param referrer: None or str, from the http request
         :param headers: dict, all headers from the http request
         :return: boolean
     """
     if headers.get(config['shadow']['http_header_name'], None):
         return True
+
+    if not referrer:
+        return False
 
     for substr in config['shadow']['referrer_blacklist']:
         if substr in referrer:


### PR DESCRIPTION
Add HTTP response headers to describe behavior.

I'm interested in doing some benchmarking of the various performance modes.
To make that easier, I've added a response header called X-tscached-mode.
It will describe the critical path that tscached followed in processing the query.

Short list of possible values:
- hot - cache hit, and data was current enough based on the config.
- warm_append - cache hit, some newer data added from Kairos.
- warm_prepend - cache hit, some older data added from Kairos.
- cold_overwrite - cache hit, but data isn't enough on both begin and end, so treated as cache miss.
- cold_miss - cache miss in the usual fashion; whole query went to Kairos.
- cold_proxy - cache is broken in some way; whole query went to Kairos.
- mixed - user submitted more than one query in the request and they had differing behaviors.

Also, a patch: Requests with no referrers should not fail!
